### PR TITLE
pull: Add concurrency level flag to pull

### DIFF
--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -15,8 +16,9 @@ var crawlCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		l := schema.NewLookup(args[0], flagLang)
+		ctx := context.Background()
 		if !l.DocExists() {
-			schema.FetchTopic(l)
+			schema.FetchTopic(ctx, l)
 		}
 		t, err := schema.ReadTopic(l)
 		fatal(err)
@@ -28,7 +30,7 @@ var crawlCmd = &cobra.Command{
 				// TODO: check last fetch, version
 				continue
 			}
-			tt := schema.FetchTopic(ll)
+			tt := schema.FetchTopic(ctx, ll)
 			fatal(writeTopic(ll, tt))
 			fmt.Fprintf(os.Stderr, "   %s [%s]\n", ll.DocPath, time.Since(tt.LastFetch))
 		}

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -26,7 +27,8 @@ var fetchCmd = &cobra.Command{
 			return
 		}
 
-		t := schema.FetchTopic(l)
+		ctx := context.Background()
+		t := schema.FetchTopic(ctx, l)
 		fatal(writeTopic(l, t))
 		fmt.Fprintf(os.Stderr, "=> %s [%s]\n", l.DocPath, time.Since(t.LastFetch))
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,8 @@ var (
 	flagShow bool
 	flagLang string
 
+	flagPullConcurrency int
+
 	rootCmd = &cobra.Command{
 		Version: Version,
 		Use:     "macschema",
@@ -24,6 +26,8 @@ func init() {
 	rootCmd.AddCommand(crawlCmd)
 	rootCmd.AddCommand(fetchCmd)
 	rootCmd.AddCommand(pullCmd)
+
+	pullCmd.Flags().IntVar(&flagPullConcurrency, "concurrency", 1, "number of concurrent workers")
 
 	rootCmd.PersistentFlags().BoolVar(&flagShow, "show", false, "show resulting JSON to stdout")
 	rootCmd.PersistentFlags().StringVar(&flagLang, "lang", "objc", "use language")

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/chromedp/chromedp v0.6.10
 	github.com/go-test/deep v1.0.7
 	github.com/spf13/cobra v1.1.3
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 )

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/schema/fetch.go
+++ b/schema/fetch.go
@@ -10,10 +10,10 @@ import (
 	"github.com/chromedp/chromedp"
 )
 
-func FetchTopic(l Lookup) Topic {
+func FetchTopic(ctx context.Context, l Lookup) Topic {
 	u, _ := url.Parse(l.URL)
 
-	ctx, cancel := chromedp.NewContext(context.Background())
+	ctx, cancel := chromedp.NewContext(ctx)
 	defer cancel()
 	ctx, cancel = context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
@@ -27,7 +27,7 @@ func FetchTopic(l Lookup) Topic {
 		chromedp.Navigate(u.String()),
 		chromedp.WaitVisible(`main div.topictitle`),
 	)
-	dur := time.Duration(1 * time.Second)
+	dur := time.Duration(5 * time.Second)
 	short, _ := context.WithTimeout(ctx, dur)
 	go chromedp.Run(short, chromedp.Text(`main div.topictitle h1.title`, &t.Title))
 	short, _ = context.WithTimeout(ctx, dur)

--- a/schema/fetch.go
+++ b/schema/fetch.go
@@ -27,7 +27,7 @@ func FetchTopic(ctx context.Context, l Lookup) Topic {
 		chromedp.Navigate(u.String()),
 		chromedp.WaitVisible(`main div.topictitle`),
 	)
-	dur := time.Duration(5 * time.Second)
+	dur := time.Duration(1 * time.Second)
 	short, _ := context.WithTimeout(ctx, dur)
 	go chromedp.Run(short, chromedp.Text(`main div.topictitle h1.title`, &t.Title))
 	short, _ = context.WithTimeout(ctx, dur)


### PR DESCRIPTION
This adds a `--concurrency` flag to pull which will fetch sub-topics concurrently, re-using the browser process.