### PR TITLE
parse `IBOutlet` properties

### DIFF
--- a/declparse/ast.go
+++ b/declparse/ast.go
@@ -33,9 +33,10 @@ type InterfaceDecl struct {
 }
 
 type PropertyDecl struct {
-	Name  string
-	Type  TypeInfo
-	Attrs map[PropAttr]string
+	Name     string
+	Type     TypeInfo
+	Attrs    map[PropAttr]string
+	IsOutlet bool
 }
 
 type FunctionDecl struct {

--- a/declparse/ast_strings.go
+++ b/declparse/ast_strings.go
@@ -78,6 +78,9 @@ func (p PropertyDecl) String() string {
 		fmt.Fprintf(b, "(%s)", strings.Join(attrs, ", "))
 	}
 	b.WriteString(" ")
+	if p.IsOutlet {
+		b.WriteString("IBOutlet ")
+	}
 	typ := p.Type.String()
 	b.WriteString(typ)
 	if typ[len(typ)-1] != '*' {

--- a/declparse/declparse_test.go
+++ b/declparse/declparse_test.go
@@ -583,6 +583,23 @@ var tests = []struct {
 	},
 
 	{
+		s: `@property(strong) IBOutlet NSView *view;`,
+		n: &Statement{
+			Property: &PropertyDecl{
+				Name: "view",
+				Attrs: map[PropAttr]string{
+					PropAttrStrong: "",
+				},
+				Type: TypeInfo{
+					Name:  "NSView",
+					IsPtr: true,
+				},
+				IsOutlet: true,
+			},
+		},
+	},
+
+	{
 		s: `- (BOOL)writeObjects:(NSArray<id<NSPasteboardWriting>> *)objects;`,
 		n: &Statement{
 			Method: &MethodDecl{

--- a/declparse/parser_property.go
+++ b/declparse/parser_property.go
@@ -51,6 +51,12 @@ func parseProperty(p *Parser) (next stateFn, node Node, err error) {
 		p.tb.Unscan()
 	}
 
+	if tok, _, lit := p.tb.Scan(); tok == lexer.IDENT && lit == "IBOutlet" {
+		decl.IsOutlet = true
+	} else {
+		p.tb.Unscan()
+	}
+
 	typ, err := p.expectType(false)
 	if err != nil {
 		return nil, nil, err

--- a/schema/astconv.go
+++ b/schema/astconv.go
@@ -54,8 +54,9 @@ func ArgFromAst(ai declparse.ArgInfo) Arg {
 
 func PropertyFromAst(p declparse.PropertyDecl) Property {
 	prop := Property{
-		Name: p.Name,
-		Type: DataTypeFromAst(p.Type),
+		Name:     p.Name,
+		Type:     DataTypeFromAst(p.Type),
+		IsOutlet: p.IsOutlet,
 	}
 	attrs := make(map[string]interface{})
 	for attr, val := range p.Attrs {

--- a/schema/types.go
+++ b/schema/types.go
@@ -94,6 +94,7 @@ type Property struct {
 	Declaration string
 	Type        DataType
 	Attrs       map[string]interface{}
+	IsOutlet    bool   `json:",omitempty"`
 	Deprecated  bool   `json:",omitempty"`
 	TopicURL    string `json:",omitempty"`
 }


### PR DESCRIPTION
Handles parsing properties declared with the `IBOutlet` modifier used
by Interface Builder.

Includes a test based on this declaration:
https://developer.apple.com/documentation/appkit/nsviewcontroller/1434401-view?language=objc

Fixes #8
